### PR TITLE
lower complexity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.idea/
+package-lock.json
 
 npm-debug.log*
 yarn-debug.log*

--- a/README.md
+++ b/README.md
@@ -14,14 +14,13 @@ import SimpleCarousel from 'react-hgs-simple-carousel';
 import 'es6-simple-carousel/dist/styles/custom.css',
 //...
 ```
-### 2. call a refrence and config for your carousel
+### 2. make config for your carousel
 ```jsx
 // ...
-import React, {useRef} from 'react';
+import React from 'react';
 
 //...
 // on main function
-const myCarousel = useRef(null);
 const slideConfig = {
   threshold: 50,
   infinite: true,
@@ -42,10 +41,10 @@ const slideConfig = {
 };
 // ....
 ```
-### 3. use refrence and config on your component's body
+### 3. use config on your component's body
 ```jsx
   <div class="container">
-      <SimpleCarousel className="myCarousel" slideConfig={slideConfig} refrence={myCarousel} >
+      <SimpleCarousel className="myCarousel" slideConfig={slideConfig}>
           <span className="slide">Slide 1</span>
           <span className="slide">Slide 2</span>
           <span className="slide">Slide 3</span>
@@ -62,12 +61,11 @@ const slideConfig = {
 for EX:
 
 ```jsx
-import React, {useRef } from 'react';
+import React from 'react';
 import SimpleCarousel from './components/slider';
 import 'es6-simple-carousel/dist/styles/custom.css';
 
 function App() {
-  const myCarousel = useRef(null);
   const slideConfig = {
     threshold: 50,
     infinite: true,
@@ -89,7 +87,7 @@ function App() {
 
   return (
     <div className="container">
-      <SimpleCarousel className="myCarousel" slideConfig={slideConfig} refrence={myCarousel} >
+      <SimpleCarousel className="myCarousel" slideConfig={slideConfig} >
           <span className="slide">Slide 1</span>
           <span className="slide">Slide 2</span>
           <span className="slide">Slide 3</span>

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/preset-react": "^7.7.4"
   },
   "dependencies": {
-    "es6-simple-carousel": "^1.0.3"
+    "es6-simple-carousel": "^1.0.3",
+    "prop-types": "^15.7.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,32 @@
-import React, { useEffect } from 'react';
-import { Slider } from 'es6-simple-carousel';
-import 'es6-simple-carousel/dist/styles/slider.css';
+import React, { useEffect, useRef } from "react";
+import PropTypes from "prop-types";
+import { Slider } from "es6-simple-carousel";
+import "es6-simple-carousel/dist/styles/slider.css";
 
 function SimpleCarousel(props) {
-  const { className, children,slideConfig,refrence } = props;
+  const { className, children, slideConfig } = props;
+  const refrence = useRef();
   useEffect(() => {
     new Slider({
-        slider:refrence.current,
-        ...slideConfig
-      }
-    );
-  }, [className, refrence, slideConfig,children]);
+      slider: refrence.current,
+      ...slideConfig
+    });
+  }, []);
 
   return (
-    <div className={`slider${!!className ? ` ${className}` : ''}`} ref={refrence}>
-      <div className="wrapper">
-        <div className="slides">
-          {children}
+      <div className={`slider ${className}`} ref={refrence}>
+        <div className="wrapper">
+          <div className="slides">{children}</div>
         </div>
       </div>
-    </div>
   );
 }
+SimpleCarousel.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node.isRequired,
+  slideConfig: PropTypes.object.isRequired
+};
+SimpleCarousel.defaultProps = {
+  className: ""
+};
 export default SimpleCarousel;


### PR DESCRIPTION
removed ref from slider parent cause there is no need to pass refrence from out side of the slider.
use effect should be call one time to avoid making new instances from slider.